### PR TITLE
Fix ServiceStatusView popover presenting too many times

### DIFF
--- a/StatusBuddy/Views/ServiceStatusView.swift
+++ b/StatusBuddy/Views/ServiceStatusView.swift
@@ -37,9 +37,9 @@ struct ServiceStatusView: View {
             Circle()
                 .frame(width: 10, height: 10, alignment: .center)
                 .foregroundColor(service.statusColor)
-                .onHover(perform: { _ in
+                .onHover(perform: { hover in
                     if !self.service.events.isEmpty {
-                        self.circleHover.toggle()
+                        self.circleHover = hover
                     }
                 })
                 .popover(isPresented: $circleHover, content: {


### PR DESCRIPTION
When scrolling, the hover event gets called many times causing the popover to be presented and dismissed repeatedly.

| Before | After |
|--|--|
|![before](https://user-images.githubusercontent.com/1749664/79977343-0742ca80-8496-11ea-8ca5-adf39c033224.gif)|![after](https://user-images.githubusercontent.com/1749664/79977349-0ad65180-8496-11ea-99e2-99b3f2cf2833.gif)|

